### PR TITLE
Add support for HTML and Markdown + option for colored title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ config.yml
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -116,19 +116,19 @@ pbcli application show $PB_APPLICATION --url https://pushbits.example.com --user
 
 ### Message options
 
-Messages are supporting thre different syntaxes:
+Messages are supporting three different syntaxes:
 
 * text/plain
 * text/html
 * text/markdown
 
-To set a specific syntax you need to set the `extras`:
+To set a specific syntax you need to set the `extras` ([inspired by Gotifys message extras](https://gotify.net/docs/msgextras#clientdisplay)):
 
 ```bash
 curl \
 	--header "Content-Type: application/json" \
 	--request POST \
-	--data '{"message":"my message with\n\n**Markdown** _support_.","title":"my title","extras":{"client::display":{"contentType": "text/html"}}}' \
+	--data '{"message":"my message with\n\n**Markdown** _support_.","title":"my title","extras":{"client::display":{"contentType": "text/markdown"}}}' \
 	"https://pushbits.example.com/message?token=$PB_TOKEN"
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ You can retrieve the token using [pbcli](https://github.com/PushBits/cli) by run
 pbcli application show $PB_APPLICATION --url https://pushbits.example.com --username $PB_USERNAME
 ```
 
+### Message options
+
+Messages are supporting thre different syntaxes:
+
+* text/plain
+* text/html
+* text/markdown
+
+To set a specific syntax you need to set the `extras`:
+
+```bash
+curl \
+	--header "Content-Type: application/json" \
+	--request POST \
+	--data '{"message":"my message with\n\n**Markdown** _support_.","title":"my title","extras":{"client::display":{"contentType": "text/html"}}}' \
+	"https://pushbits.example.com/message?token=$PB_TOKEN"
+```
+
+HTML-Content might not be fully rendered in your Matrix-Client - see the corresponding [Matrix specs](https://spec.matrix.org/unstable/client-server-api/#mroommessage-msgtypes). This also holds for Markdown, as it is transfered to the corresponding HTML-syntax.
+
 ## Acknowledgments
 
 The idea for this software and most parts of the initial source are heavily inspired by [Gotify](https://gotify.net/).

--- a/cmd/pushbits/main.go
+++ b/cmd/pushbits/main.go
@@ -47,7 +47,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	dp, err := dispatcher.Create(db, c.Matrix.Homeserver, c.Matrix.Username, c.Matrix.Password)
+	dp, err := dispatcher.Create(db, c.Matrix.Homeserver, c.Matrix.Username, c.Matrix.Password, c.Message)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/pushbits/main.go
+++ b/cmd/pushbits/main.go
@@ -47,7 +47,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	dp, err := dispatcher.Create(db, c.Matrix.Homeserver, c.Matrix.Username, c.Matrix.Password, c.Message)
+	dp, err := dispatcher.Create(db, c.Matrix.Homeserver, c.Matrix.Username, c.Matrix.Password, c.Formatting)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/config.example.yml
+++ b/config.example.yml
@@ -58,5 +58,5 @@ crypto:
         keylength: 32
 
 formatting: 
-    # Whether to use colored titles based on the message priority.
+    # Whether to use colored titles based on the message priority (<0: grey, 0-3: default, 4-10: yellow, 10-20: orange, >20: red).
     coloredtitle: false

--- a/config.example.yml
+++ b/config.example.yml
@@ -56,3 +56,7 @@ crypto:
         parallelism: 4
         saltlength: 16
         keylength: 32
+
+message: 
+    # add coloring to the title according to syslog priorities
+    # coloredtitle: true

--- a/config.example.yml
+++ b/config.example.yml
@@ -57,6 +57,6 @@ crypto:
         saltlength: 16
         keylength: 32
 
-message: 
-    # add coloring to the title according to syslog priorities
-    # coloredtitle: true
+formatting: 
+    # Whether to use colored titles based on the message priority.
+    coloredtitle: false

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-playground/validator/v10 v10.3.0 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20210408062403-ad838ccf8cdd
 	github.com/google/go-cmp v0.5.0 // indirect
 	github.com/jinzhu/configor v1.2.1
 	github.com/json-iterator/go v1.1.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/gomarkdown/markdown v0.0.0-20210408062403-ad838ccf8cdd h1:0b8AqsWQb6A0jjx80UXLG/uMTXQkGD0IGuXWqsrNz1M=
+github.com/gomarkdown/markdown v0.0.0-20210408062403-ad838ccf8cdd/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -83,6 +85,7 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ugorji/go/codec v1.2.4 h1:C5VurWRRCKjuENsbM6GYVw8W++WVW9rSxoACKIvxzz8=
 github.com/ugorji/go/codec v1.2.4/go.mod h1:bWBu1+kIRWcF8uMklKaJrR6fTWQOwAlrIzX22pHwryA=
+golang.org/dl v0.0.0-20190829154251-82a15e2f2ead/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/internal/api/notification.go
+++ b/internal/api/notification.go
@@ -30,6 +30,7 @@ type NotificationHandler struct {
 // CreateNotification is used to create a new notification for a user.
 func (h *NotificationHandler) CreateNotification(ctx *gin.Context) {
 	var notification model.Notification
+	notification.Priority = 8 // set a default value
 
 	if err := ctx.Bind(&notification); err != nil {
 		return

--- a/internal/api/notification.go
+++ b/internal/api/notification.go
@@ -30,7 +30,6 @@ type NotificationHandler struct {
 // CreateNotification is used to create a new notification for a user.
 func (h *NotificationHandler) CreateNotification(ctx *gin.Context) {
 	var notification model.Notification
-	notification.Priority = 8 // set a default value
 
 	if err := ctx.Bind(&notification); err != nil {
 		return

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -42,7 +42,8 @@ type Configuration struct {
 	Security struct {
 		CheckHIBP bool `default:"false"`
 	}
-	Crypto CryptoConfig
+	Crypto  CryptoConfig
+	Message map[string]interface{}
 }
 
 func configFiles() []string {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -18,6 +18,11 @@ type CryptoConfig struct {
 	Argon2 Argon2Config
 }
 
+// Formatting holds additional parameters used for formatting messages
+type Formatting struct {
+	ColoredTitle bool `default:"false"`
+}
+
 // Configuration holds values that can be configured by the user.
 type Configuration struct {
 	Debug bool `default:"false"`
@@ -42,8 +47,8 @@ type Configuration struct {
 	Security struct {
 		CheckHIBP bool `default:"false"`
 	}
-	Crypto  CryptoConfig
-	Message map[string]interface{}
+	Crypto     CryptoConfig
+	Formatting Formatting
 }
 
 func configFiles() []string {

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -16,12 +16,13 @@ type Database interface {
 
 // Dispatcher holds information for sending notifications to clients.
 type Dispatcher struct {
-	db     Database
-	client *gomatrix.Client
+	db       Database
+	client   *gomatrix.Client
+	settings map[string]interface{}
 }
 
 // Create instanciates a dispatcher connection.
-func Create(db Database, homeserver, username, password string) (*Dispatcher, error) {
+func Create(db Database, homeserver, username, password string, settings map[string]interface{}) (*Dispatcher, error) {
 	log.Println("Setting up dispatcher.")
 
 	client, err := gomatrix.NewClient(homeserver, "", "")
@@ -40,7 +41,7 @@ func Create(db Database, homeserver, username, password string) (*Dispatcher, er
 
 	client.SetCredentials(response.UserID, response.AccessToken)
 
-	return &Dispatcher{client: client}, nil
+	return &Dispatcher{client: client, settings: settings}, nil
 }
 
 // Close closes the dispatcher connection.

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/matrix-org/gomatrix"
+	"github.com/pushbits/server/internal/configuration"
 )
 
 var (
@@ -16,13 +17,13 @@ type Database interface {
 
 // Dispatcher holds information for sending notifications to clients.
 type Dispatcher struct {
-	db       Database
-	client   *gomatrix.Client
-	settings map[string]interface{}
+	db         Database
+	client     *gomatrix.Client
+	formatting configuration.Formatting
 }
 
 // Create instanciates a dispatcher connection.
-func Create(db Database, homeserver, username, password string, settings map[string]interface{}) (*Dispatcher, error) {
+func Create(db Database, homeserver, username, password string, formatting configuration.Formatting) (*Dispatcher, error) {
 	log.Println("Setting up dispatcher.")
 
 	client, err := gomatrix.NewClient(homeserver, "", "")
@@ -41,7 +42,7 @@ func Create(db Database, homeserver, username, password string, settings map[str
 
 	client.SetCredentials(response.UserID, response.AccessToken)
 
-	return &Dispatcher{client: client, settings: settings}, nil
+	return &Dispatcher{client: client, formatting: formatting}, nil
 }
 
 // Close closes the dispatcher connection.

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -32,12 +32,8 @@ func (d *Dispatcher) getFormattedTitle(n *model.Notification) string {
 	trimmedTitle := strings.TrimSpace(n.Title)
 	title := html.EscapeString(trimmedTitle)
 
-	if valueRaw, ok := d.settings["coloredtitle"]; ok {
-		value, ok := valueRaw.(bool)
-
-		if ok && value {
-			title = d.coloredText(d.priorityToColor(n.Priority), title)
-		}
+	if d.formatting.ColoredTitle {
+		title = d.coloredText(d.priorityToColor(n.Priority), title)
 	}
 
 	return "<b>" + title + "</b><br /><br />"

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -46,7 +46,6 @@ func (d *Dispatcher) getFormattedMessage(n *model.Notification) string {
 
 	if optionsDisplayRaw, ok := n.Extras["client::display"]; ok {
 		optionsDisplay, ok := optionsDisplayRaw.(map[string]interface{})
-		log.Printf("%s", optionsDisplay)
 
 		if ok {
 			if contentTypeRaw, ok := optionsDisplay["contentType"]; ok {
@@ -69,23 +68,18 @@ func (d *Dispatcher) getFormattedMessage(n *model.Notification) string {
 
 // Maps priorities to hex colors
 func (d *Dispatcher) priorityToColor(prio int) string {
-	switch prio {
-	case 0: // emergency - dark red
-		return "#cc0000"
-	case 1: // alert - red
-		return "#ed1f11"
-	case 2: // critical - dark orange
-		return "#ed6d11"
-	case 3: // error - orange
-		return "#edab11"
-	case 4: // warning - yellow
-		return "#edd711"
-	case 5: // notice - green
-		return "#70ed11"
-	case 6: // informational - blue
-		return "#118eed"
-	case 7: // debug - grey
+	log.Printf("Prio: %d", prio)
+	switch {
+	case prio < 0:
 		return "#828282"
+	case prio <= 3: // info - default color
+		return ""
+	case prio <= 10: // low - yellow
+		return "#edd711"
+	case prio <= 20: // mid - orange
+		return "#ed6d11"
+	case prio > 20: // high - red
+		return "#ed1f11"
 	}
 
 	return ""

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -68,7 +68,6 @@ func (d *Dispatcher) getFormattedMessage(n *model.Notification) string {
 
 // Maps priorities to hex colors
 func (d *Dispatcher) priorityToColor(prio int) string {
-	log.Printf("Prio: %d", prio)
 	switch {
 	case prio < 0:
 		return "#828282"

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/gomarkdown/markdown"
 	"github.com/pushbits/server/internal/model"
 )
 
@@ -16,10 +17,36 @@ func (d *Dispatcher) SendNotification(a *model.Application, n *model.Notificatio
 	plainTitle := strings.TrimSpace(n.Title)
 	plainMessage := strings.TrimSpace(n.Message)
 	escapedTitle := html.EscapeString(plainTitle)
-	escapedMessage := html.EscapeString(plainMessage)
+	message := html.EscapeString(plainMessage) // default to text/plain
+
+	if optionsDisplayRaw, ok := n.Extras["client::display"]; ok {
+		optionsDisplay, ok := optionsDisplayRaw.(map[string]interface{})
+		log.Printf("%s", optionsDisplay)
+
+		if ok {
+			if contentTypeRaw, ok := optionsDisplay["contentType"]; ok {
+				contentType := fmt.Sprintf("%v", contentTypeRaw)
+				log.Printf("Message content type: %s", contentType)
+
+				switch contentType {
+				case "html", "text/html":
+					message = plainMessage
+				case "markdown", "md", "text/md", "text/markdown":
+					message = string(markdown.ToHTML([]byte(plainMessage), nil, nil))
+				}
+			}
+		}
+	}
+
+	// TODO cubicroot: add colors for priority https://spec.matrix.org/unstable/client-server-api/#mroommessage-msgtypes
+	// maybe make this optional in the settings or so
+
+	// TODO cubicroot: check if we somehow can handle \n or other methods of line breaks
+
+	// TODO cubicroot: add docu
 
 	text := fmt.Sprintf("%s\n\n%s", plainTitle, plainMessage)
-	formattedText := fmt.Sprintf("<b>%s</b><br /><br />%s", escapedTitle, escapedMessage)
+	formattedText := fmt.Sprintf("<b>%s</b><br /><br />%s", escapedTitle, message)
 
 	_, err := d.client.SendFormattedText(a.MatrixID, text, formattedText)
 


### PR DESCRIPTION
**Changes:**

* Added support for HTML and Markdown #25 
* Added support for priority based coloring of the title

**Testing:** 

1. Markdown syntax: 

```
 curl --header "Content-Type: application/json" --request POST --data '{"message":"This does now **support** _Markdown_\n\n Great, isnt it?","title":"my title","extras": {"client::display": {"contentType": "text/markdown"}}}' "yourdomain.tld/message?token=XXXXXXX"
```

For testing HTML simply switch `contentType` to `text/html`. Be aware that not all clients support all HTML tags, not even the recommend one's from the Matrix specs.

2. Colored title

Add this to your config.yml:

```
message:
  coloredtitle: true
```

and send a message with priority:

```
 curl --header "Content-Type: application/json" --request POST --data '{"message":"This does now **support** _Markdown_\n\n Great, isnt it?","title":"my title","extras": {"client::display": {"contentType": "text/markdown"}},"priority": 1}' "yourdomain.tld/message?token=XXXXXXX"
```
