### PR TITLE
Add delete endpoint for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ curl \
 
 HTML-Content might not be fully rendered in your Matrix-Client - see the corresponding [Matrix specs](https://spec.matrix.org/unstable/client-server-api/#mroommessage-msgtypes). This also holds for Markdown, as it is transfered to the corresponding HTML-syntax.
 
+### Deleting a Message
+
+You can delete a message, this will send a notification in response to the original message informing you that the message is "deleted". 
+
+You need the message ID for deleting a message. As it might contain characters not valid in uris we provide an additional `id_url_encoded` field for messages, use that value for deleting a message.
+
+```bash
+curl \
+	--request DELETE \
+	"https://pushbits.example.com/message/${MESSAGE_ID}?token=$PB_TOKEN"
+```
+
 ## 👮&nbsp;Acknowledgments
 
 The idea for this software and most parts of the initial source are heavily inspired by [Gotify](https://gotify.net/).

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -20,6 +20,17 @@ func getID(ctx *gin.Context) (uint, error) {
 	return id, nil
 }
 
+func getMessageID(ctx *gin.Context) (string, error) {
+	id, ok := ctx.MustGet("messageid").(string)
+	if !ok {
+		err := errors.New("an error occured while retrieving messageID from context")
+		ctx.AbortWithError(http.StatusInternalServerError, err)
+		return "", err
+	}
+
+	return id, nil
+}
+
 func getApplication(ctx *gin.Context, db Database) (*model.Application, error) {
 	id, err := getID(ctx)
 	if err != nil {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -2,4 +2,4 @@ package api
 
 import "errors"
 
-var ErrorMessageNotFound = errors.New("Message not found")
+var ErrorMessageNotFound = errors.New("message not found")

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,5 @@
+package api
+
+import "errors"
+
+var ErrorMessageNotFound = errors.New("Message not found")

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -8,6 +8,10 @@ type idInURI struct {
 	ID uint `uri:"id" binding:"required"`
 }
 
+type messageIdInURI struct {
+	MessageID string `uri:"messageid" binding:"required"`
+}
+
 // RequireIDInURI returns a Gin middleware which requires an ID to be supplied in the URI of the request.
 func RequireIDInURI() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
@@ -18,5 +22,18 @@ func RequireIDInURI() gin.HandlerFunc {
 		}
 
 		ctx.Set("id", requestModel.ID)
+	}
+}
+
+// RequireMessageIDInURI returns a Gin middleware which requires an messageID to be supplied in the URI of the request.
+func RequireMessageIDInURI() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		var requestModel messageIdInURI
+
+		if err := ctx.BindUri(&requestModel); err != nil {
+			return
+		}
+
+		ctx.Set("messageid", requestModel.MessageID)
 	}
 }

--- a/internal/api/notification.go
+++ b/internal/api/notification.go
@@ -3,6 +3,7 @@ package api
 import (
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -52,6 +53,7 @@ func (h *NotificationHandler) CreateNotification(ctx *gin.Context) {
 	}
 
 	notification.ID = messageID
+	notification.UrlEncodedID = url.QueryEscape(messageID)
 
 	ctx.JSON(http.StatusOK, &notification)
 }
@@ -70,5 +72,9 @@ func (h *NotificationHandler) DeleteNotification(ctx *gin.Context) {
 		Date: time.Now(),
 	}
 
-	h.DP.DeleteNotification(application, &n)
+	if success := successOrAbort(ctx, http.StatusInternalServerError, h.DP.DeleteNotification(application, &n)); !success {
+		return
+	}
+
+	ctx.Status(http.StatusOK)
 }

--- a/internal/api/notification.go
+++ b/internal/api/notification.go
@@ -19,6 +19,7 @@ type NotificationDatabase interface {
 // The NotificationDispatcher interface for relaying notifications.
 type NotificationDispatcher interface {
 	SendNotification(a *model.Application, n *model.Notification) error
+	SendDeleteNotification(a *model.Application, n *model.DeleteNotification) error
 }
 
 // NotificationHandler holds information for processing requests about notifications.
@@ -50,4 +51,12 @@ func (h *NotificationHandler) CreateNotification(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, &notification)
+}
+
+func (h *NotificationHandler) DeleteNotification(ctx *gin.Context) {
+	application := authentication.GetApplication(ctx)
+
+	n := model.DeleteNotification{}
+
+	h.DP.SendDeleteNotification(application, &n)
 }

--- a/internal/api/util.go
+++ b/internal/api/util.go
@@ -11,7 +11,13 @@ import (
 
 func successOrAbort(ctx *gin.Context, code int, err error) bool {
 	if err != nil {
-		ctx.AbortWithError(code, err)
+		// If we know the error force error code
+		switch err {
+		case ErrorMessageNotFound:
+			ctx.AbortWithError(http.StatusNotFound, err)
+		default:
+			ctx.AbortWithError(code, err)
+		}
 	}
 
 	return err == nil

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -265,9 +265,11 @@ func bodiesFromMessage(message gomatrix.Event) (body, formattedBody string, err 
 
 	if val, ok := message.Content["formatted_body"]; ok {
 		body, ok := val.(string)
-		if ok {
-			formattedBody = body
+		if !ok {
+			return "", "", api.ErrorMessageNotFound
 		}
+
+		formattedBody = body
 	}
 
 	return body, formattedBody, nil

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -82,10 +82,15 @@ func (d *Dispatcher) DeleteNotification(a *model.Application, n *model.DeleteNot
 
 	if val, ok := deleteMessage.Content["body"]; ok {
 		body, ok := val.(string)
-		if ok {
-			oldBody = body
-			oldFormattedBody = body
+
+		if !ok {
+			log.Println("Event does not have a body")
+			return api.ErrorMessageNotFound
 		}
+
+		oldBody = body
+		oldFormattedBody = body
+
 	} else {
 		log.Println("Message to delete has wrong format")
 		return api.ErrorMessageNotFound

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -7,6 +7,7 @@ import (
 // Notification holds information like the message, the title, and the priority of a notification.
 type Notification struct {
 	ID            string                 `json:"id"`
+	UrlEncodedID  string                 `json:"id_url_encoded"`
 	ApplicationID uint                   `json:"appid"`
 	Message       string                 `json:"message" form:"message" query:"message" binding:"required"`
 	Title         string                 `json:"title" form:"title" query:"title"`

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -6,7 +6,7 @@ import (
 
 // Notification holds information like the message, the title, and the priority of a notification.
 type Notification struct {
-	ID            uint                   `json:"id"`
+	ID            string                 `json:"id"`
 	ApplicationID uint                   `json:"appid"`
 	Message       string                 `json:"message" form:"message" query:"message" binding:"required"`
 	Title         string                 `json:"title" form:"title" query:"title"`
@@ -17,11 +17,6 @@ type Notification struct {
 
 // DeleteNotification holds information like the message, the reply to message id and the priority of a deletion notification.
 type DeleteNotification struct {
-	ID            uint                   `json:"id"`
-	DeleteID      uint                   `json:"deleteid"`
-	ApplicationID uint                   `json:"appid"`
-	Message       string                 `json:"message" form:"message" query:"message" binding:"required"`
-	Priority      int                    `json:"priority" form:"priority" query:"priority"`
-	Extras        map[string]interface{} `json:"extras,omitempty" form:"-" query:"-"`
-	Date          time.Time              `json:"date"`
+	ID   string    `json:"id" form:"id"`
+	Date time.Time `json:"date"`
 }

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -16,7 +16,7 @@ type Notification struct {
 	Date          time.Time              `json:"date"`
 }
 
-// DeleteNotification holds information like the message, the reply to message id and the priority of a deletion notification.
+// DeleteNotification holds information like the message ID of a deletion notification.
 type DeleteNotification struct {
 	ID   string    `json:"id" form:"id"`
 	Date time.Time `json:"date"`

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -14,3 +14,14 @@ type Notification struct {
 	Extras        map[string]interface{} `json:"extras,omitempty" form:"-" query:"-"`
 	Date          time.Time              `json:"date"`
 }
+
+// DeleteNotification holds information like the message, the reply to message id and the priority of a deletion notification.
+type DeleteNotification struct {
+	ID            uint                   `json:"id"`
+	DeleteID      uint                   `json:"deleteid"`
+	ApplicationID uint                   `json:"appid"`
+	Message       string                 `json:"message" form:"message" query:"message" binding:"required"`
+	Priority      int                    `json:"priority" form:"priority" query:"priority"`
+	Extras        map[string]interface{} `json:"extras,omitempty" form:"-" query:"-"`
+	Date          time.Time              `json:"date"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -48,8 +48,6 @@ func Create(debug bool, cm *credentials.Manager, db *database.Database, dp *disp
 	r.POST("/message", auth.RequireApplicationToken(), notificationHandler.CreateNotification)
 	r.DELETE("/message/:messageid", api.RequireMessageIDInURI(), auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
 
-	r.GET("/test", auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
-
 	userGroup := r.Group("/user")
 	userGroup.Use(auth.RequireAdmin())
 	{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -46,7 +46,7 @@ func Create(debug bool, cm *credentials.Manager, db *database.Database, dp *disp
 	r.GET("/health", healthHandler.Health)
 
 	r.POST("/message", auth.RequireApplicationToken(), notificationHandler.CreateNotification)
-	r.DELETE("/message/:messageid", api.RequireIDInURI(), auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
+	r.DELETE("/message/:messageid", api.RequireMessageIDInURI(), auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
 
 	r.GET("/test", auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -47,6 +47,8 @@ func Create(debug bool, cm *credentials.Manager, db *database.Database, dp *disp
 
 	r.POST("/message", auth.RequireApplicationToken(), notificationHandler.CreateNotification)
 
+	r.GET("/test", auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
+
 	userGroup := r.Group("/user")
 	userGroup.Use(auth.RequireAdmin())
 	{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -46,6 +46,7 @@ func Create(debug bool, cm *credentials.Manager, db *database.Database, dp *disp
 	r.GET("/health", healthHandler.Health)
 
 	r.POST("/message", auth.RequireApplicationToken(), notificationHandler.CreateNotification)
+	r.DELETE("/message/:messageid", api.RequireIDInURI(), auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
 
 	r.GET("/test", auth.RequireApplicationToken(), notificationHandler.DeleteNotification)
 


### PR DESCRIPTION
Added a delete endpoint for messages. It is using the matrix event id as identifier. 

If you delete a message the following will happen:
* the message will be striked through and a "- deleted" will be added at the end
* you will receive a notification in reply to this message that it got deleted

![Unbenannt](https://user-images.githubusercontent.com/24812442/121174888-b8532280-c85a-11eb-875f-fdea500c1d10.PNG)

I choose this way as that would offer a nice opportunity for alerting - the message will not be silently removed, Matrix will inform you about the deletion - that could be the resolving of an alert.

Another small detailed I changed: I added an "error to HTTP status code" mapping to the `successOrAbort` method. My thoughts about that are that we do not need to handle that in every handler separately and that it will encourage us to use predefined errors what will make the code more consistence. 

_Please don't feel presured about the next pr I opened - definetely no need to rush here, just lots of spare time on my site._ 