### PR TITLE
Fix token lengths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,12 @@ build:
 
 .PHONY: test
 test:
-	stdout=$$(gofmt -l . 2>&1); \
-	if [ "$$stdout" ]; then \
-		exit 1; \
-	fi
+	stdout=$$(gofmt -l . 2>&1); if [ "$$stdout" ]; then exit 1; fi
 	go vet ./...
 	gocyclo -over 10 $(shell find . -iname '*.go' -type f)
 	staticcheck ./...
 	go test -v -cover ./...
+	@printf '\n%s\n' "> Test successful"
 
 .PHONY: setup
 setup:

--- a/internal/authentication/token.go
+++ b/internal/authentication/token.go
@@ -53,5 +53,7 @@ func GenerateApplicationToken(compat bool) string {
 		tokenLength = compatTokenLength
 	}
 
+	tokenLength -= len(applicationTokenPrefix)
+
 	return applicationTokenPrefix + generateRandomString(tokenLength)
 }

--- a/internal/authentication/token_test.go
+++ b/internal/authentication/token_test.go
@@ -7,12 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	minTokenLength = 14
+)
+
 func isGoodToken(assert *assert.Assertions, require *require.Assertions, token string, compat bool) {
 	if compat {
 		assert.Equal(len(token), compatTokenLength, "Unexpected compatibility token length")
 	} else {
 		assert.Equal(len(token), regularTokenLength, "Unexpected regular token length")
 	}
+
+	assert.GreaterOrEqual(len(token), minTokenLength, "Token is too short to give sufficient entropy")
 
 	prefix := token[0:len(applicationTokenPrefix)]
 

--- a/internal/authentication/token_test.go
+++ b/internal/authentication/token_test.go
@@ -1,7 +1,6 @@
 package authentication
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,19 +8,13 @@ import (
 )
 
 func isGoodToken(assert *assert.Assertions, require *require.Assertions, token string, compat bool) {
-	prefix := token[0:len(applicationTokenPrefix)]
-	token = token[len(applicationTokenPrefix):]
-
-	// Although constant at the time of writing, this check should prevent future changes from generating insecure tokens.
-	if len(token) < 14 {
-		log.Fatalf("Tokens should have more random characters")
-	}
-
 	if compat {
 		assert.Equal(len(token), compatTokenLength, "Unexpected compatibility token length")
 	} else {
 		assert.Equal(len(token), regularTokenLength, "Unexpected regular token length")
 	}
+
+	prefix := token[0:len(applicationTokenPrefix)]
 
 	assert.Equal(prefix, applicationTokenPrefix, "Invalid token prefix")
 

--- a/internal/authentication/token_test.go
+++ b/internal/authentication/token_test.go
@@ -8,20 +8,22 @@ import (
 )
 
 const (
-	minTokenLength = 14
+	minRandomChars = 14
 )
 
 func isGoodToken(assert *assert.Assertions, require *require.Assertions, token string, compat bool) {
+	tokenLength := len(token)
+
 	if compat {
-		assert.Equal(len(token), compatTokenLength, "Unexpected compatibility token length")
+		assert.Equal(tokenLength, compatTokenLength, "Unexpected compatibility token length")
 	} else {
-		assert.Equal(len(token), regularTokenLength, "Unexpected regular token length")
+		assert.Equal(tokenLength, regularTokenLength, "Unexpected regular token length")
 	}
 
-	assert.GreaterOrEqual(len(token), minTokenLength, "Token is too short to give sufficient entropy")
+	randomChars := tokenLength - len(applicationTokenPrefix)
+	assert.GreaterOrEqual(randomChars, minRandomChars, "Token is too short to give sufficient entropy")
 
 	prefix := token[0:len(applicationTokenPrefix)]
-
 	assert.Equal(prefix, applicationTokenPrefix, "Invalid token prefix")
 
 	for _, c := range []byte(token) {


### PR DESCRIPTION
As discovered by @CubicrootXYZ in #38, the tokens currently generated are too long. The issue goes back to 9c228164959c854f205acfe1929952097c6985e9. Most importantly, any applications created with the `compat` flag were created with a token not conforming to Gotify's specification.