### PR TITLE
Sanitize notification before processing it

### DIFF
--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"strings"
 	"time"
 )
 
@@ -14,6 +15,17 @@ type Notification struct {
 	Priority      int                    `json:"priority" form:"priority" query:"priority"`
 	Extras        map[string]interface{} `json:"extras,omitempty" form:"-" query:"-"`
 	Date          time.Time              `json:"date"`
+}
+
+// Sanitize sets explicit defaults for a notification.
+func (n *Notification) Sanitize(application *Application) {
+	n.ID = ""
+	n.UrlEncodedID = ""
+	n.ApplicationID = application.ID
+	if strings.TrimSpace(n.Title) == "" {
+		n.Title = application.Name
+	}
+	n.Date = time.Now()
 }
 
 // DeleteNotification holds information like the message ID of a deletion notification.


### PR DESCRIPTION
The `ID` and `UrlEncodedID` fields were not sanitized before passing the notification to `SendNotification()`. It's not a problem now, but I think we should be careful with implicit input.