### PR TITLE
Exclude tests when generating API docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,26 @@
-OUTDIR := ./out
+# References:
+# [1] Needed so the Go files of semgrep-rules do not interfere with static analysis
 
-SEMGREP_MODFILE := ./tests/semgrep-rules/go.mod
+DOCS_DIR := ./docs
+OUT_DIR := ./out
+TESTS_DIR := ./tests
+
+SEMGREP_MODFILE := $(TESTS_DIR)/semgrep-rules/go.mod
 
 .PHONY: build
 build:
-	mkdir -p $(OUTDIR)
-	go build -ldflags="-w -s" -o $(OUTDIR)/pushbits ./cmd/pushbits
+	mkdir -p $(OUT_DIR)
+	go build -ldflags="-w -s" -o $(OUT_DIR)/pushbits ./cmd/pushbits
 
 .PHONY: clean
 clean:
-	rm -rf $(OUTDIR)
+	rm -rf $(DOCS_DIR)
+	rm -rf $(OUT_DIR)
 	rm -rf $(SEMGREP_MODFILE)
 
 .PHONY: test
 test:
-	touch $(SEMGREP_MODFILE) # Needed so the Go files of semgrep-rules do not interfere with static analysis
+	touch $(SEMGREP_MODFILE) # See [1].
 	go fmt ./...
 	go vet ./...
 	gocyclo -over 10 $(shell find . -type f \( -iname '*.go' ! -path "./tests/semgrep-rules/*" \))
@@ -22,7 +28,7 @@ test:
 	go test -v -cover ./...
 	gosec -exclude-dir=tests ./...
 	semgrep --lang=go --config=tests/semgrep-rules/go --metrics=off
-	rm -rf $(SEMGREP_MODFILE)
+	rm -rf $(SEMGREP_MODFILE) # See [1].
 	@printf '\n%s\n' "> Test successful"
 
 .PHONY: setup
@@ -36,4 +42,4 @@ setup:
 
 .PHONY: swag
 swag:
-	swag init --parseDependency=true -d . -g cmd/pushbits/main.go
+	swag init --parseDependency=true --exclude $(TESTS_DIR) -g cmd/pushbits/main.go


### PR DESCRIPTION
This patch fixes the pipeline for generating our API docs.