### PR TITLE
#49 Fix empty notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ setup:
 	go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
 	go install github.com/swaggo/swag/cmd/swag@latest
-	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
+	poetry install
 
 .PHONY: swag
 swag:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ setup:
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
 	go install github.com/swaggo/swag/cmd/swag@latest
 	go install honnef.co/go/tools/cmd/staticcheck@latest
-	poetry install
 
 .PHONY: swag
 swag:

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -33,7 +33,7 @@ type MessageEvent struct {
 	MsgType       MsgType       `json:"msgtype"`
 	RelatesTo     RelatesTo     `json:"m.relates_to,omitempty"`
 	Format        MessageFormat `json:"format"`
-	NewContent    NewContent    `json:"m.new_content,omitempty"`
+	NewContent    *NewContent   `json:"m.new_content,omitempty"`
 }
 
 // RelatesTo holds information about relations to other message events
@@ -212,7 +212,7 @@ func (d *Dispatcher) replaceMessage(a *model.Application, newBody, newFormattedB
 		Body:          oldBody,
 		FormattedBody: oldFormattedBody,
 		MsgType:       MsgTypeText,
-		NewContent:    newMessage,
+		NewContent:    &newMessage,
 		RelatesTo:     replaceRelation,
 		Format:        MessageFormatHTML,
 	}

--- a/internal/dispatcher/notification.go
+++ b/internal/dispatcher/notification.go
@@ -31,7 +31,7 @@ type MessageEvent struct {
 	Body          string        `json:"body"`
 	FormattedBody string        `json:"formatted_body"`
 	MsgType       MsgType       `json:"msgtype"`
-	RelatesTo     RelatesTo     `json:"m.relates_to,omitempty"`
+	RelatesTo     *RelatesTo    `json:"m.relates_to,omitempty"`
 	Format        MessageFormat `json:"format"`
 	NewContent    *NewContent   `json:"m.new_content,omitempty"`
 }
@@ -213,7 +213,7 @@ func (d *Dispatcher) replaceMessage(a *model.Application, newBody, newFormattedB
 		FormattedBody: oldFormattedBody,
 		MsgType:       MsgTypeText,
 		NewContent:    &newMessage,
-		RelatesTo:     replaceRelation,
+		RelatesTo:     &replaceRelation,
 		Format:        MessageFormatHTML,
 	}
 
@@ -252,7 +252,7 @@ func (d *Dispatcher) respondToMessage(a *model.Application, body, formattedBody 
 	notificationRelation := RelatesTo{
 		InReplyTo: notificationReply,
 	}
-	notificationEvent.RelatesTo = notificationRelation
+	notificationEvent.RelatesTo = &notificationRelation
 
 	return d.mautrixClient.SendMessageEvent(mId.RoomID(a.MatrixID), event.EventMessage, &notificationEvent)
 }


### PR DESCRIPTION
Fixes empty notifications (#49) due to malformed requests. 

# Testing

Please ensure to test usual messages that do not need the `NewContent` part of the request as well as messages needing those (e.g. via the delete message endpoint).