### PR TITLE
Add support for setting trusted proxies

### DIFF
--- a/cmd/pushbits/main.go
+++ b/cmd/pushbits/main.go
@@ -82,7 +82,10 @@ func main() {
 		log.L.Fatal(err)
 	}
 
-	engine := router.Create(c.Debug, cm, db, dp)
+	engine, err := router.Create(c.Debug, c.HTTP.TrustedProxies, cm, db, dp)
+	if err != nil {
+		log.L.Fatal(err)
+	}
 
 	err = runner.Run(engine, c.HTTP.ListenAddress, c.HTTP.Port)
 	if err != nil {

--- a/config.example.yml
+++ b/config.example.yml
@@ -13,6 +13,9 @@ http:
     # The port to listen on.
     port: 8080
 
+    # What proxies to trust.
+    trustedproxies: []
+
 database:
     # Currently sqlite3 and mysql are supported.
     dialect: 'sqlite3'

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -37,8 +37,9 @@ type Matrix struct {
 type Configuration struct {
 	Debug bool `default:"false"`
 	HTTP  struct {
-		ListenAddress string `default:""`
-		Port          int    `default:"8080"`
+		ListenAddress  string   `default:""`
+		Port           int      `default:"8080"`
+		TrustedProxies []string `default:"[]"`
 	}
 	Database struct {
 		Dialect    string `default:"sqlite3"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Create a Gin engine and setup all routes.
-func Create(debug bool, cm *credentials.Manager, db *database.Database, dp *dispatcher.Dispatcher) *gin.Engine {
+func Create(debug bool, trustedProxies []string, cm *credentials.Manager, db *database.Database, dp *dispatcher.Dispatcher) (*gin.Engine, error) {
 	log.L.Println("Setting up HTTP routes.")
 
 	if !debug {
@@ -29,6 +29,16 @@ func Create(debug bool, cm *credentials.Manager, db *database.Database, dp *disp
 
 	r := gin.New()
 	r.Use(log.GinLogger(log.L), gin.Recovery())
+
+	var err error
+	if len(trustedProxies) > 0 {
+		err = r.SetTrustedProxies(trustedProxies)
+	} else {
+		err = r.SetTrustedProxies(nil)
+	}
+	if err != nil {
+		return nil, err
+	}
 
 	r.Use(location.Default())
 
@@ -59,5 +69,5 @@ func Create(debug bool, cm *credentials.Manager, db *database.Database, dp *disp
 		userGroup.PUT("/:id", api.RequireIDInURI(), userHandler.UpdateUser)
 	}
 
-	return r
+	return r, nil
 }


### PR DESCRIPTION
This patch closes #53, addressing a warning by the Gin framework not to trust all proxies.

@CubicrootXYZ, in its current state the changes would break existing configurations where PushBits runs behind a proxy. One can make the case to force breaking these configurations for the sake of the user's security, so I'd like to have your input on this :)