### PR TITLE
ci: Bump go version to address vulnerabilities

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Export GOBIN
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.5'
 
       - name: Install dependencies
         run: make setup

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Export GOBIN
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.5'
 
       - name: Install dependencies
         run: make setup
@@ -86,7 +86,7 @@ jobs:
       - name: Export GOBIN
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.5'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Export GOBIN
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.5'
 
       - name: Install dependencies
         run: make setup


### PR DESCRIPTION
On another branch in my fork, I noticed some govulncheck violations in Github actions.

go version 1.20.2 has some vulnerabilities, details at:

- https://pkg.go.dev/vuln/GO-2023-1840
- https://pkg.go.dev/vuln/GO-2023-1705
- https://pkg.go.dev/vuln/GO-2023-1704
- https://pkg.go.dev/vuln/GO-2023-1753
- https://pkg.go.dev/vuln/GO-2023-1752
- https://pkg.go.dev/vuln/GO-2023-1751
- https://pkg.go.dev/vuln/GO-2023-1737
- https://pkg.go.dev/vuln/GO-2023-1703
- https://pkg.go.dev/vuln/GO-2023-1702

They've been addressed in the new go version.

Here's an example run of the test workflow working: https://github.com/rafaelespinoza/pushbits_server/actions/runs/5316577120