### PR TITLE
ci: replace goreleaser --rm-dist with --clean

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should fix the failing CI job, according to the [deprecation notices](https://goreleaser.com/deprecations/#-rm-dist) `--rm-dist` is deprecated.